### PR TITLE
Ignore cookie headings without domain=

### DIFF
--- a/webapp.py
+++ b/webapp.py
@@ -215,7 +215,8 @@ def check_cookies(link):
     about how cookies will be handled by browsers.</a>
     """
     domain = extract_service_domain_from_link(link)[1]
-    cookie_domain = "domain=" + domain
+    cookie_header = "domain="
+    cookie_domain = cookie_header + domain
     url = urllib2.urlopen(link)
     headers = url.info().headers
     for header in headers:
@@ -230,7 +231,7 @@ def check_cookies(link):
                 check_description += "<br /><br />Secure is not set<br />"
                 check_description += "&nbsp;&nbsp;Set-Cookie: %s<br />" % value
                 failed = True
-            if cookie_domain not in cookie_settings:
+            if cookie_header in cookie_settings and cookie_domain not in cookie_settings:
                 check_description += "<br /><br />Cookie not scoped to domain=%s<br />" % domain
                 check_description += "&nbsp;&nbsp;Set-Cookie: %s<br />" % value
                 failed = True


### PR DESCRIPTION
Cookies without the domain explicitly set assume the current domain name:

http://en.wikipedia.org/wiki/HTTP_cookie#Domain_and_Path

This would be bad for a top-level domain (eg `gov.uk`), but is valid for the typical service subdomain as it's only scoped to their `www.` domain. Given this, we should correctly pass `set-cookie` headers that don't contain an explicit domain.
